### PR TITLE
Add minimap during exploration

### DIFF
--- a/game/builder.c
+++ b/game/builder.c
@@ -1370,7 +1370,7 @@ void redraw_scene()
   schovej_mysku();
   if (one_buffer) RestoreScreen();
   OutBuffer2nd();
-  if (battle || (game_extras & EX_ALWAYS_MINIMAP)) draw_medium_map();
+  if (battle || minimap_enabled || (game_extras & EX_ALWAYS_MINIMAP)) draw_medium_map();
   other_draw();
   if (cur_mode == MD_END_GAME) {
       death_screen();

--- a/game/globals.h
+++ b/game/globals.h
@@ -620,6 +620,7 @@ extern char lodka_battle_draw;  //jedncka pokud se zobrazuje programovani (pro l
 extern char anim_mirror;     //je li 1 pak animace kouzel a zbrani jsou zrcadlove otocene
 extern char insleep;         //je li 1 pak bezi sleep
 extern char pass_zavora;     //je-li 1 pak bezi passing (hraci zrovna jdou)
+extern char minimap_enabled; //povoluje zobrazeni minimapy podle konfigurace
 extern short moving_player;   //cislo presouvaneho hrace
 extern int bgr_distance; //vzdalenost pozadi od pohledu
 extern int bgr_handle;  //cislo handle k obrazku pozadi;

--- a/game/realgame.c
+++ b/game/realgame.c
@@ -1689,11 +1689,11 @@ void step_zoom(char smer)
      sort_groups();
      bott_draw(0);
      other_draw();
-    if (!nopass) shift_zoom(smer);
-    if (battle || (game_extras & EX_ALWAYS_MINIMAP)) draw_medium_map();
-    sort_groups();
-    bott_draw(0);
-    other_draw();
+     if (!nopass) shift_zoom(smer);
+     if (battle || minimap_enabled || (game_extras & EX_ALWAYS_MINIMAP)) draw_medium_map();
+     sort_groups();
+     bott_draw(0);
+     other_draw();
      }
   update_mysky();
   ukaz_mysku();
@@ -1745,7 +1745,7 @@ void turn_zoom(int smer) {
         turn_right();
     }
     chod_s_postavama(0);
-    if (battle || (game_extras & EX_ALWAYS_MINIMAP))
+    if (battle || minimap_enabled || minimap_enabled || (game_extras & EX_ALWAYS_MINIMAP))
         draw_medium_map();
     update_mysky();
     ukaz_mysku();
@@ -2035,5 +2035,3 @@ int postavy_propadnout(int sector)
      }
   return z;
   }
-
-

--- a/game/skeldal.c
+++ b/game/skeldal.c
@@ -57,6 +57,7 @@ char autosave_enabled=1;
 int32_t game_time=0;
 int charmin=3;
 int charmax=3;
+char minimap_enabled=0;
 
 int autoopenaction=0;
 int autoopendata=0;
@@ -1081,6 +1082,9 @@ int init_skeldal(const INI_CONFIG *cfg, void (*game_thread)(va_list), ...)
   va_list args;
   va_start(args,game_thread);
 
+  const INI_CONFIG_SECTION *gameplay = ini_section_open(cfg, "gameplay");
+  minimap_enabled = ini_get_boolean(gameplay, "exploration_minimap", 0) != 0;
+  
   int verr = game_display_init(ini_section_open(cfg, "video"), "Skeldal",
               init_skeldal_thread, cfg, game_thread, &args);
   if (verr < 0)

--- a/skeldal.ini
+++ b/skeldal.ini
@@ -137,6 +137,11 @@
 #mod+button13=backspace
 
 
+### gameplay options
+#
+[gameplay]
+# exploration_minimap=on
+
 ### localization settings
 #
 # keyboard_layout = cz_querty, cz_quertz, us
@@ -144,4 +149,3 @@
 #                (note, internal fonts supports only characters from KEYBCS2/CP895 code page)
 #                (https://en.wikipedia.org/wiki/Kamenick%C3%BD_encoding)
 #
-


### PR DESCRIPTION
- Add new configuration settings to show minimap in exploration

```
# skeldal.ini
### gameplay options
#
[gameplay]
exploration_minimap=on
```

<img width="1272" height="950" alt="image" src="https://github.com/user-attachments/assets/80fe228d-1ea0-4bae-bb25-750b39be70e6" />

Closes: #6 
